### PR TITLE
fix: provide multiple access tokens at random for scaling the github …

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"context"
+	"math/rand"
 	"net/url"
+	"strings"
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/netlify/git-gateway/conf"
@@ -106,7 +108,10 @@ func getAccessToken(ctx context.Context) string {
 	if obj == nil {
 		return ""
 	}
-	return obj.(string)
+
+	tokens := strings.Split(obj.(string), ",")
+
+	return tokens[rand.Intn(len(tokens))]
 }
 
 func getInstanceID(ctx context.Context) string {


### PR DESCRIPTION
Github API rate limits the requests if too many editors are using a single token at once.  You can specify an env variable that has multiple tokens to randomly select the one to use for that particular request:

```sh
GITGATEWAY_GITHUB_ACCESS_TOKEN="pat_1,pat_2,pat_3"
```